### PR TITLE
MODFQMMGR-690 Add app-platform-minimal as a dependency

### DIFF
--- a/app-fqm.template.json
+++ b/app-fqm.template.json
@@ -5,6 +5,10 @@
   "platform": "complete",
   "dependencies": [
     {
+      "name": "app-platform-minimal",
+      "version": "^1.0.0-SNAPSHOT"
+    },
+    {
       "name": "app-platform-complete",
       "version": "^1.0.0-SNAPSHOT"
     },


### PR DESCRIPTION
FQM needs app-platform-minimal, as it depends on mod-users, mod-roles-keycloak, and mod-permissions