### PR TITLE
MODFQMMGR-690 Remove edge-fqm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Application descriptor repository for the FOLIO FQM (FOLIO Query Machine) applic
 |:----------------------|
 | `mod-fqm-manager`     |
 | `mod-lists`           |
-| `edge-fqm`            |
 
 ## UI Modules
 

--- a/app-fqm.template.json
+++ b/app-fqm.template.json
@@ -25,10 +25,6 @@
     {
       "name": "mod-lists",
       "version": "latest"
-    },
-    {
-      "name": "edge-fqm",
-      "version": "latest"
     }
   ],
   "uiModules": [


### PR DESCRIPTION
edge-fqm is included in the separate app-edge-complete for now, so it's not needed here